### PR TITLE
Fix text overflows in the intro section for mobile screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -308,7 +308,16 @@ header.singleNav nav ul {
       background-size: 20rem;
     }
 
+  .intro {
+    margin-top: calc(2.5rem + var(--spacing-medium) * 2);
+    height: auto;
+    min-height: calc(100vh - (2.5rem + var(--spacing-medium) * 2));
+  }
+
 }
 
 @media only screen and (max-width: 375px) {
+  body {
+    min-width: unset;
+  }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -233,6 +233,10 @@ header h1 {
   width: 70%;
 }
 
+.intro > div > p:not(:first-of-type):not(:last-of-type) {
+  margin: var(--spacing-base) 0;
+}
+
 .pinnedList .card {
   pointer-events: none;
 }
@@ -312,6 +316,10 @@ header.singleNav nav ul {
     margin-top: calc(2.5rem + var(--spacing-medium) * 2);
     height: auto;
     min-height: calc(100vh - (2.5rem + var(--spacing-medium) * 2));
+  }
+
+  .intro p a {
+    margin: 0
   }
 
 }

--- a/mobile/index.html
+++ b/mobile/index.html
@@ -19,10 +19,10 @@
 		<a href="#content" class="assistiveText">Skip to Main Content</a>
 		<div class="wrapper">
 			<div class="logoMark"></div>
-			<h1 class="logo"><a href="#">OnionShare</a></h1>
+			<h1 class="logo">OnionShare</h1>
 			<nav id="navigation">
 				<ul>
-					<li><a href="https://onionshare.org/">Home</a></li>
+					<li><a href="/">Home</a></li>
 				</ul>
 			</nav>
 		</div>
@@ -36,11 +36,22 @@
 			<div>
 				<!-- <div class="icon large onionshare"></div> -->
 				<h2>OnionShare Mobile is Ready for Testing!</h2>
-				<p>The OnionShare teams working with Tor Project, Calyx Institute and Guardian Project, have created the official OnionShare mobile apps for Android and iOS.
-The apps are now in public beta testing phase, ready for feedback on stability, usability and privacy controls.
-</p>
-<br/><br/>
-<p><span class="warning">WARNING: These apps are not yet audited, and in early alpha/beta state. Please only use for testing.<br/>Report any issues to <a href="mailto:support@guardianproject.info">Guardian Project Support Helpdesk</a><br/>or Github on <a href="https://github.com/onionshare">the appropriate Github project</span></p> 
+				<p>The OnionShare teams working with Tor Project, Calyx Institute and Guardian Project, 
+					have created the official OnionShare mobile apps for Android and iOS.
+					The apps are now in public beta testing phase, ready for feedback on stability, 
+					usability and privacy controls.
+				</p>
+				<br/><br/>
+				<p class="warning">
+					WARNING: These apps are not yet audited, and in early alpha/beta state. 
+					Please only use for testing.
+				</p>
+				<p class="warning">
+					Report any issues to 
+					<a href="mailto:support@guardianproject.info">Guardian Project Support Helpdesk</a>
+					<br/>
+					or Github on <a href="https://github.com/onionshare">the appropriate Github project</a>
+				</p> 
 				<a role="button" class="btn primaryBtn firstAction" href="#download">Join Mobile Testing</a>
 			</div>
 		</section>


### PR DESCRIPTION
This is how it looks in iphone 11 pro.
![image](https://user-images.githubusercontent.com/9530293/162565384-1bf38d7b-f642-4400-b3f3-06ea04798d2a.png)

I have also fixed it for android devices with smaller screen width and height.