### PR TITLE
Cleaned up mobile menu

### DIFF
--- a/design-system/components/header/css/header.css
+++ b/design-system/components/header/css/header.css
@@ -68,7 +68,6 @@ header .logo {
   height: var(--size-logo);
   padding: calc(var(--spacing-medium) * 1.125) 0;
   line-height: var(--line-height-base);
-  display: flex;
   width: fit-content;
   position: relative;
   top: -1px;
@@ -111,7 +110,11 @@ nav.staged {
   display: none;
 }
 
-.open {
+header.open {
+  border-radius: var(--radius-header) var(--radius-header) 0 0 !important;
+}
+
+ul.open {
   display: initial !important;
 }
 
@@ -168,7 +171,7 @@ nav .badge {
 header.island {
   width: fit-content;
   margin: var(--spacing-base) auto 0 auto;
-  border-radius: var(--radius-round);
+  border-radius: var(--radius-header);
 }
 
 header.island .wrapper {
@@ -195,7 +198,7 @@ header.island nav ul li a.wrapper {
   @media (prefers-color-scheme: light) {
     header nav ul {
       box-shadow: var(--shadow-lm);
-      background-color: var(--color-light);
+      background-color: var(--color-light-translucent);
       border: var(--border-dark);
     }
 
@@ -207,9 +210,8 @@ header.island nav ul li a.wrapper {
   @media (prefers-color-scheme: dark) {
     header nav ul {
       box-shadow: var(--shadow-dm);
-      background-color: var(--color-shade-dm);
+      background-color: var(--color-dark-translucent);
       border: var(--border-light);
-
     }
 
     header nav ul li a:hover {
@@ -248,15 +250,15 @@ header.island nav ul li a.wrapper {
   }
 
  header.island nav ul {
-    flex-direction: column;
-    position: absolute;
-    top: 56px;
-    right: 0;
-    width: max-content;
+    position: fixed;
+    top: 60px;
+    right: -1px;
+    width: 100%;
     z-index: 1;
     padding: var(--spacing-small) 0;
-    align-items: flex-start;
-    border-radius: var(--radius-soft);
+    border-radius: 0 0 var(--radius-header) var(--radius-header);
+    backdrop-filter: blur(var(--spacing-base));
+    -webkit-backdrop-filter: blur(var(--spacing-base));
   }
 
   header nav ul li a.wrapper {

--- a/design-system/components/header/js/header.js
+++ b/design-system/components/header/js/header.js
@@ -2,10 +2,12 @@ $(document).ready(function() {
 
   $('.btnIcon').on('click', function() {
     $('header nav ul').toggleClass('open');
+    $('header').toggleClass('open');
   });
 
   $('NAV li').on('click', function() {
     $('header nav ul').removeClass('open');
+    $('header').removeClass('open');
   });
 
 });

--- a/design-system/css/variables.css
+++ b/design-system/css/variables.css
@@ -75,4 +75,5 @@
   --radius-soft: .25rem;
   --radius-softer: .5rem;
   --radius-round: 50vw;
+  --radius-header: 30px;
 }

--- a/design-system/js/design-system.js
+++ b/design-system/js/design-system.js
@@ -12,6 +12,7 @@ $(document).ready(function() {
 
   $('.mobileNav').on('click', function() {
     $('header nav ul').toggleClass('open');
+    $('header').toggleClass('open');
     if ($('.mobileNav').attr('aria-expanded') == 'false') {
       $('.mobileNav').attr('aria-expanded', 'true');
     } else {
@@ -21,6 +22,7 @@ $(document).ready(function() {
 
   $('NAV li').on('click', function() {
     $('header nav ul').removeClass('open');
+    $('header').removeClass('open');
   });
 
   $('.bannerBtn').on('click', function() {


### PR DESCRIPTION
Fixes #38. Tossed a few unneeded lines (flex styling w/ block display, duplicate lines) and cleaned up the mobile menu a bit. @glenn-sorrentino let me know if there's anyway I can make this better fit into the design system or if you prefer it in overrides. 

## Screenshots

*closed menu (same as before)*
<img src="https://github.com/user-attachments/assets/76000b5e-e68c-48f0-9438-0f14ea112d8a" width="50%">


*opened menu*
<img src="https://github.com/user-attachments/assets/ff3a0586-6593-4b60-911b-ba5c5e8482ea" width="50%">
