### PR TITLE
Add (minor): add mastodon account attribution and verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,13 @@
 	<meta name="author" content="Science & Design, Inc - scidsg.org">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="description" content="OnionShare is a tool for anonymous peer-to-peer file sharing, chatting, and web hosting.">
+	<meta name="fediverse:creator" content="@lockdownsystems@infosec.exchange">
 
 	<title>OnionShare</title>
 
 	<link rel="icon" type="image/x-icon" href="favicon.ico">
 	<link rel="stylesheet" href="design-system/css/style.css">
+	<link href="https://infosec.exchange/@lockdownsystems" rel="me">
 
 	<script src="design-system/js/jquery-min.js"></script>
 	<script src="design-system/js/design-system.js"></script>


### PR DESCRIPTION
This will create an attribution to the Lockdown Systems Mastodon account for each link to the OnionShare website posted on the Fediverse, and will allow to verify the OnionShare website from the Lockdown Systems Mastodon account.